### PR TITLE
Fixed dark style for Brackets Sprint 43 dark style.

### DIFF
--- a/extension/styles/main.css
+++ b/extension/styles/main.css
@@ -83,6 +83,7 @@ span.ext-daily{
 }
 
 .ext-avatar{
+    background: #f0f0f0;
     margin-right: 5px;
     border-radius: 4px;
     width: 20px;


### PR DESCRIPTION
This PR makes sure that extension rating is ready for Brackets Sprint 43's dark style.

Mostly color tweaks.
# Before:

![screen shot 2014-08-17 at 3 05 01 pm](https://cloud.githubusercontent.com/assets/1495261/3946022/3598946c-265c-11e4-9eb2-84633777b74b.png)
# After:

![screen shot 2014-08-17 at 3 11 24 pm](https://cloud.githubusercontent.com/assets/1495261/3946027/42fc4ab8-265c-11e4-9ad7-d733dd2c890f.png)
